### PR TITLE
fix: return key instead of index when calling key method [fix #1]

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -33,8 +33,8 @@ const dbFile = resolve(tmpdir(), `${randomUUID()}.sqlite`);
 	});
 
 	test(`${type}.key() - Valid Index`, () => {
-		const expected = 'Hello, world';
-		storage.setItem('demo', expected);
+		const expected = 'demo';
+		storage.setItem(expected, 'Hello, world!');
 
 		const actual = storage.key(0);
 
@@ -50,8 +50,8 @@ const dbFile = resolve(tmpdir(), `${randomUUID()}.sqlite`);
 	});
 
 	test(`${type}.key() - Valid Fraction Index`, () => {
-		const expected = 'Hello, world';
-		storage.setItem('demo', expected);
+		const expected = 'demo';
+		storage.setItem(expected, 'Hello, world');
 
 		const actual = storage.key(0.1);
 

--- a/index.ts
+++ b/index.ts
@@ -69,10 +69,10 @@ export function createLocalStorage(fileName: string): Storage {
 		 */
 		key(index: unknown): string | null {
 			const normalizedIndex = parseInt(String(index), 10) || 0;
-			const query = db.prepare('SELECT value FROM kv ORDER BY key LIMIT 1 OFFSET ?');
+			const query = db.prepare('SELECT key FROM kv ORDER BY key LIMIT 1 OFFSET ?');
 			const item = query.get(normalizedIndex) as KeyValuePair;
 
-			return item ? item.value : null;
+			return item ? item.key : null;
 		},
 
 		/**


### PR DESCRIPTION
- changed the key method to return the key from the database and return it to the calling method
- changed the tests to reference the key instead of the value stored
